### PR TITLE
add placeholders

### DIFF
--- a/src/modules/forms/plugins/RequestTransformer/HeadersSection/HeadersSection.js
+++ b/src/modules/forms/plugins/RequestTransformer/HeadersSection/HeadersSection.js
@@ -40,6 +40,7 @@ class HeadersSection extends Component {
                                             name={`${member}.key`}
                                             type="text"
                                             component={Input}
+                                            placeholder="Key"
                                         />
                                     </div>
                                     <div className={row('item', {pair: true})}>
@@ -47,6 +48,7 @@ class HeadersSection extends Component {
                                             name={`${member}.value`}
                                             type="text"
                                             component={Input}
+                                            placeholder="Value"
                                         />
                                     </div>
                                     <div className={row('control')()}>


### PR DESCRIPTION
On mockups it's `Key` and `Value` placeholders. Should I leave them like that? Or change to `Header name` and `Value`, @italolelis ?