### PR TITLE
Input Component: Do not return undefined as classname if no error

### DIFF
--- a/src/modules/inputs/Input.js
+++ b/src/modules/inputs/Input.js
@@ -7,7 +7,7 @@ const Input = props => {
 
     return (
         <input
-            className={`j-input ${!disabled && meta.error && meta.touched && ' j-input--error'}`}
+            className={`j-input${(!disabled && meta.error && meta.touched) ? ' j-input--error' : ''}`}
             type={type}
             placeholder={placeholder}
             disabled={disabled}


### PR DESCRIPTION
This PR removes [`undefined` className][1] on [all][2] input components that doesn't have input errors.

[1]: https://user-images.githubusercontent.com/1451155/32049961-6cdc1bb2-ba4f-11e7-962c-344cb9730f04.png
[2]: https://user-images.githubusercontent.com/1451155/32050007-94e0fd1c-ba4f-11e7-8230-de053dc6704a.png
