### PR TITLE
TagSelect Component: Return empty array if value is empty when splitting

### DIFF
--- a/src/modules/selects/TagSelect/TagSelect.js
+++ b/src/modules/selects/TagSelect/TagSelect.js
@@ -39,7 +39,7 @@ class TagSelect extends Component {
 
     handleOnChange = value => {
         this.setState((prevState, props) => ({ multiValue: value }));
-        this.props.input.onChange(value.split(','));
+        this.props.input.onChange((value) ? value.split(',') : []);
     }
 
     render() {


### PR DESCRIPTION
Fixes `TagSelect` having [empty string element](https://user-images.githubusercontent.com/1451155/32055050-d9ca5c46-ba60-11e7-887f-d722185ecbe3.png) when all its values are removed or reset.
