### PR TITLE
Remove redundant upstreams url columns

### DIFF
--- a/src/modules/Layout/Table/Table.scss
+++ b/src/modules/Layout/Table/Table.scss
@@ -20,7 +20,7 @@ $icon-height: 14px;
     &__row {
         border-bottom: $hf-border;
         display: grid;
-        grid-template-columns: 35% 25% 20% 10% 10%;
+        grid-template-columns: 39% 41% 10% 10%;
 
         &:last-child {
             border-bottom: none;

--- a/src/modules/pages/ApiListPage/ApiList.js
+++ b/src/modules/pages/ApiListPage/ApiList.js
@@ -48,7 +48,6 @@ class ApiList extends PureComponent {
         <div className={table('row')} key={`${index}-${api.name}`}>
             <div className={table('td', {name: true})}>{api.name}</div>
             <div className={table('td')}>{api.proxy.listen_path}</div>
-            <div className={table('td')}>{api.proxy.upstream_url}</div>
             <div className={table('td', {active: true})}>
                 {api.active ? <Icon type="checked" /> : null}
             </div>
@@ -97,7 +96,7 @@ class ApiList extends PureComponent {
                         <div className="ascending-icon"></div>
                     </div>
                     <div className={table('th')}>Listen Path</div>
-                    <div className={table('th')}>Upstream URL</div>
+
                     <div
                         className={table('th', {active: true}).mix('ascending-container')}
                         onClick={() => this.sortList('active')}

--- a/src/modules/pages/OAuthServersPage/OAuthServersList.js
+++ b/src/modules/pages/OAuthServersPage/OAuthServersList.js
@@ -51,7 +51,6 @@ class OAuthServersList extends PureComponent {
         return (
             <div className={table('row')} key={`${index}-${server.name}`}>
                 <div className={table('td', {name: true})}>{server.name}</div>
-                <div className={table('td', {name: true})}>{tokenUrl}</div>
                 <div className={table('td', {name: true})}></div>
                 <div className={table('td', {name: true})}></div>
                 <div className={table('td').mix(table('controls'))}>
@@ -88,7 +87,6 @@ class OAuthServersList extends PureComponent {
                         <div>OAuth Server Name</div>
                         <div className="ascending-icon"></div>
                     </div>
-                    <div className={table('th')}>Upstream URL</div>
                 </div>
             </div>
             <div className={table('tbody')}>


### PR DESCRIPTION
This **PR** removes redundant columns with _Upstreams URL_, because, at this point, there is nothing to display.