### PR TITLE
Remove 'copy' and 'delete' buttons from all froms except edit page

### DIFF
--- a/src/modules/forms/EndpointForm/EndpointForm.js
+++ b/src/modules/forms/EndpointForm/EndpointForm.js
@@ -131,35 +131,40 @@ class EndpointForm extends PureComponent {
             <form className={b} onSubmit={handleSubmit}>
                 <Section>
                     <Row>
-                        <Title>Edit API</Title>
-                        <div className="j-buttons__wrapper">
-                            <Link
-                                to={{
-                                    pathname: '/new',
-                                    state: {
-                                        clone: api,
-                                    },
-                                }}
-                            >
-                                <Button
-                                    type="button"
-                                    mod="primary"
-                                >
-                                    <Icon type="copy-white" />
-                                    Copy
-                                </Button>
-                            </Link>
-                            <Button
-                                type="button"
-                                mod="danger"
-                                onClick={() => {
-                                    handleDelete(api.name);
-                                }}
-                            >
-                                <Icon type="delete-white" />
-                                Delete
-                            </Button>
-                        </div>
+                        <Title>
+                            { editing ? 'Edit API' : 'Create New API' }
+                        </Title>
+                        {
+                            editing && api.name &&
+                                <div className="j-buttons__wrapper">
+                                    <Link
+                                        to={{
+                                            pathname: '/new',
+                                            state: {
+                                                clone: api,
+                                            },
+                                        }}
+                                    >
+                                        <Button
+                                            type="button"
+                                            mod="primary"
+                                        >
+                                            <Icon type="copy-white" />
+                                            Copy
+                                        </Button>
+                                    </Link>
+                                    <Button
+                                        type="button"
+                                        mod="danger"
+                                        onClick={() => {
+                                            handleDelete(api.name);
+                                        }}
+                                    >
+                                        <Icon type="delete-white" />
+                                        Delete
+                                    </Button>
+                                </div>
+                        }
                     </Row>
                 </Section>
                 <div className={b('inner')}>


### PR DESCRIPTION
This **PR** removes unnecessary buttons on top of the forms, as far as we don't need to have "copy" and/or "delete" buttons on the form of the endpoint which doesn't exist yet.