### PR TITLE
Move transformations to helper function to make it reusable

### DIFF
--- a/src/helpers/getUpdatedEndpoint.js
+++ b/src/helpers/getUpdatedEndpoint.js
@@ -4,9 +4,9 @@ import transformFormValues from './transformFormValues';
 const getUpdatedEndpoint = values => selectedPlugins => {
     const getTransformedValues = values => transformFormValues(values, true);
     const extractPlugins = obj => obj.plugins;
-    const getAddedPlugins = arr => arr.filter(plugin => {
-        return selectedPlugins.indexOf(plugin.name) !== -1;
-    });
+    const getAddedPlugins = arr => arr.filter(plugin =>
+        selectedPlugins.indexOf(plugin.name) !== -1
+    );
     const createUpdatedEndpoint = arr => ({
         ...getTransformedValues(values),
         plugins: arr,

--- a/src/helpers/getUpdatedEndpoint.js
+++ b/src/helpers/getUpdatedEndpoint.js
@@ -1,0 +1,23 @@
+import R from 'ramda';
+import transformFormValues from './transformFormValues';
+
+const getUpdatedEndpoint = values => selectedPlugins => {
+    const getTransformedValues = values => transformFormValues(values, true);
+    const extractPlugins = obj => obj.plugins;
+    const getAddedPlugins = arr => arr.filter(plugin => {
+        return selectedPlugins.indexOf(plugin.name) !== -1;
+    });
+    const createUpdatedEndpoint = arr => ({
+        ...getTransformedValues(values),
+        plugins: arr,
+    });
+
+    return R.compose(
+        createUpdatedEndpoint,
+        getAddedPlugins,
+        extractPlugins,
+        getTransformedValues,
+    )(values);
+};
+
+export default getUpdatedEndpoint;

--- a/src/modules/pages/EditPage/ApiItem.js
+++ b/src/modules/pages/EditPage/ApiItem.js
@@ -1,8 +1,9 @@
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import R from 'ramda';
 import PropTypes from 'prop-types';
 
 import transformFormValues from '../../../helpers/transformFormValues';
+import getUpdatedEndpoint from '../../../helpers/getUpdatedEndpoint';
 
 import EndpointForm from '../../forms/EndpointForm/EndpointForm';
 import Preloader from '../../Preloader/Preloader';
@@ -21,7 +22,7 @@ const propTypes = {
     location: PropTypes.object.isRequired,
 };
 
-class ApiItem extends Component {
+class ApiItem extends PureComponent {
     componentDidMount() {
         this.props.resetEndpoint();
         this.props.fetchEndpointSchema();
@@ -35,20 +36,12 @@ class ApiItem extends Component {
     }
 
     submit = values => {
-        const transformedValues = transformFormValues(values, true);
-        const plugins = transformedValues.plugins;
-        const selectedPlugins = this.props.selectedPlugins;
+        const updatedEndpoint = getUpdatedEndpoint(values)(this.props.selectedPlugins);
 
-        const addedPlugins = plugins.filter((plugin) => {
-            return selectedPlugins.indexOf(plugin.name) !== -1;
-        });
-
-        const computedPlugins = {
-            ...transformedValues,
-            plugins: addedPlugins,
-        };
-
-        this.props.updateEndpoint(this.props.location.pathname, computedPlugins);
+        this.props.updateEndpoint(
+            this.props.location.pathname,
+            updatedEndpoint,
+        );
     }
 
     handleDelete = (apiName) => {
@@ -57,6 +50,7 @@ class ApiItem extends Component {
 
     render() {
         if (R.isEmpty(this.props.api)) return <Preloader />;
+
 
         const api = this.props.api;
         const apiPlugins = api.plugins;

--- a/src/modules/pages/NewApiPage/NewApiItem.js
+++ b/src/modules/pages/NewApiPage/NewApiItem.js
@@ -1,9 +1,10 @@
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import R from 'ramda';
 import { deleteProperty } from 'picklock';
 
 import transformFormValues from '../../../helpers/transformFormValues';
+import getUpdatedEndpoint from '../../../helpers/getUpdatedEndpoint';
 
 import Section from '../../Layout/Section/Section';
 import Subtitle from '../../Layout/Title/Subtitle';
@@ -22,7 +23,7 @@ const propTypes = {
     willClone: PropTypes.func.isRequired,
 };
 
-class NewApiItem extends Component {
+class NewApiItem extends PureComponent {
     componentDidMount() {
         this.props.resetEndpoint();
 
@@ -40,18 +41,12 @@ class NewApiItem extends Component {
     };
 
     submit = values => {
-        const transformedValues = transformFormValues(values, true);
-        const plugins = transformedValues.plugins;
-        const selectedPlugins = this.props.selectedPlugins;
-        const addedPlugins = plugins.filter((plugin) => {
-            return selectedPlugins.indexOf(plugin.name) !== -1;
-        });
-        const computedPlugins = {
-            ...transformedValues,
-            plugins: addedPlugins,
-        };
+        const updatedEndpoint = getUpdatedEndpoint(values)(this.props.selectedPlugins);
 
-        this.props.saveEndpoint(this.props.location.pathname, computedPlugins);
+        this.props.saveEndpoint(
+            this.props.location.pathname,
+            updatedEndpoint,
+        );
     }
 
     hasToBeCloned = () => {


### PR DESCRIPTION
This **PR** does:
1. move transformations to helper function, so we will reuse it in different places;
2. `Component` => `PureComponent`;