### PR TITLE
add space between logo and navigation

### DIFF
--- a/src/modules/Layout/Header/Header.scss
+++ b/src/modules/Layout/Header/Header.scss
@@ -1,9 +1,10 @@
 @import 'index.scss';
 
 $padding: $hf-gutter;
+$logo-part-width: 100px + $hf-padding-big;
 
 .j-header {
-    grid-template-columns: 100px 1fr 100px;
+    grid-template-columns: $logo-part-width 1fr 100px;
     display: grid;
     padding: 0 $hf-padding-main;
     background-color: $hellofresh-color;


### PR DESCRIPTION
This **PR** resolves _issue_https://github.com/hellofresh/janus-dashboard/issues/160
![image](https://user-images.githubusercontent.com/8372070/32606284-07983f7c-c555-11e7-861f-646be3e3c336.png)
