### PR TITLE
Adjust header grid template

### DIFF
--- a/src/modules/Layout/Header/Header.scss
+++ b/src/modules/Layout/Header/Header.scss
@@ -4,7 +4,7 @@ $padding: $hf-gutter;
 $logo-part-width: 100px + $hf-padding-big;
 
 .j-header {
-    grid-template-columns: $logo-part-width 1fr 100px;
+    grid-template-columns: $logo-part-width 2fr 1fr;
     display: grid;
     padding: 0 $hf-padding-main;
     background-color: $hellofresh-color;
@@ -30,6 +30,7 @@ $logo-part-width: 100px + $hf-padding-big;
 
     &__user {
         display: flex;
+        justify-content: flex-end;
         height: $hf-height-header;
 
         &-name {
@@ -74,4 +75,3 @@ $logo-part-width: 100px + $hf-padding-big;
         }
     }
 }
-


### PR DESCRIPTION
The current 100px width on the username column in the header is not enough.

This PR increases the width to a reasonable amount without breaking the remaining header navigation items.