### PR TITLE
Pass checked attribute to radio

### DIFF
--- a/src/modules/inputs/Radio/Radio.js
+++ b/src/modules/inputs/Radio/Radio.js
@@ -7,7 +7,11 @@ import './Radio.css';
 const radio = block('j-radio');
 
 const Radio = props => {
-    const { input, id, name, type } = props;
+    const { id, name, type, checked } = props;
+    let { input } = props;
+
+    if (checked)
+        input = {...input, checked};
 
     return (
         <div className={radio('wrap')}>

--- a/src/modules/pages/NewOAuthServerPage/OAuthServerForm.js
+++ b/src/modules/pages/NewOAuthServerPage/OAuthServerForm.js
@@ -144,9 +144,10 @@ class OAuthServerForm extends PureComponent {
                             <Field
                                 name="token_strategy.settings.use_oauth_header"
                                 component={Radio}
-                                value={'true'}
+                                value="true"
                                 type="radio"
                                 id="use-aouth-header-is-active"
+                                checked={!!this.state.strategy.settings.use_oauth_header}
                             />
                             <Label htmlFor="use-aouth-header-is-active">Yes</Label>
                         </Row>
@@ -154,9 +155,10 @@ class OAuthServerForm extends PureComponent {
                             <Field
                                 name="token_strategy.settings.use_oauth_header"
                                 component={Radio}
-                                value={'false'}
+                                value="false"
                                 type="radio"
                                 id="use-aouth-header-is-not-active"
+                                checked={!this.state.strategy.settings.use_oauth_header}
                             />
                             <Label htmlFor="use-aouth-header-is-not-active">No</Label>
                         </Row>


### PR DESCRIPTION
This PR fixes the missing default checked Radio input on OAuth Token Strategy when `introspect` is selected.