### PR TITLE
make api name clickable with redirection to edit page

### DIFF
--- a/src/modules/pages/HealthCheckPage/HealthCheckList.js
+++ b/src/modules/pages/HealthCheckPage/HealthCheckList.js
@@ -38,7 +38,11 @@ class HealthCheckList extends PureComponent {
 
     renderRows = list => list.map(item => (
         <div className={table('row')} key={item.name}>
-            <div className={table('td', { name: true })}>{item.name}</div>
+            <div className={table('td', { name: true })}>
+                <Link to={`/${item.name}`}>
+                    {item.name}
+                </Link>
+            </div>
             <div className={table('td')}>{item.description}</div>
             <div className={table('td')}></div>
             <div className={table('td').mix(table('controls'))}>


### PR DESCRIPTION
This **PR** makes name clickable and redirects to Edit page (as Edit icon does).
Resolves _issue_ https://github.com/hellofresh/janus-dashboard/issues/205