### PR TITLE
Make load balancing required

### DIFF
--- a/src/modules/forms/EndpointForm/EndpointForm.js
+++ b/src/modules/forms/EndpointForm/EndpointForm.js
@@ -244,8 +244,8 @@ class EndpointForm extends PureComponent {
                                     options={this.createStrategyOptions(apiSchema.proxy.upstreams.options)}
                                     onChange={this.handleChangeStrategy}
                                     value={this.state.upstreams.balancing}
-                                    searchable={false}
                                     clearable={false}
+                                    required
                                 />
                                 <div className={row({fullwidth: true}).mix('j-api-form__row')}>
                                     <Row className={b('row')()} fullwidth>

--- a/src/modules/pages/NewOAuthServerPage/partials/OAuthClientEndpoints/OAuthClientEndpoint.js
+++ b/src/modules/pages/NewOAuthServerPage/partials/OAuthClientEndpoints/OAuthClientEndpoint.js
@@ -122,8 +122,8 @@ class OAuthClientEndpoint extends PureComponent {
                                 options={this.createStrategyOptions(schema.oauth_client_endpoints[name].upstreams.options)}
                                 onChange={this.handleChangeStrategy}
                                 value={this.state.upstreams.balancing}
-                                searchable={false}
                                 clearable={false}
+                                required
                             />
                             <div className={row({fullwidth: true}).mix('j-api-form__row')}>
                                 <Row className={b('row')()} fullwidth>

--- a/src/modules/pages/NewOAuthServerPage/partials/OAuthEndpoints/OAuthEndpoint.js
+++ b/src/modules/pages/NewOAuthServerPage/partials/OAuthEndpoints/OAuthEndpoint.js
@@ -124,8 +124,8 @@ class OAuthEndpoint extends PureComponent {
                                 options={this.createStrategyOptions(schema.oauth_endpoints[name].upstreams.options)}
                                 onChange={this.handleChangeStrategy}
                                 value={this.state.upstreams.balancing}
-                                searchable={false}
                                 clearable={false}
+                                required
                             />
                             <div className={row({fullwidth: true}).mix('j-api-form__row')}>
                                 <Row className={b('row')()} fullwidth>


### PR DESCRIPTION
Closes #219 

Affects:
- API Endpoint form
- New OAuth Server form
- Edit OAuth Server form

There is a minor bug with `react-select`/`redux-form`:
`searchable` property has to be set to `true`, otherwise it does not render `input` and `required` will not be captured by redux-form.