### PR TITLE
Remove 'required' property from fields in inactive tab

### DIFF
--- a/src/__tests__/modules/OAuthServerForm/__snapshots__/OAuthServerForm.test.js.snap
+++ b/src/__tests__/modules/OAuthServerForm/__snapshots__/OAuthServerForm.test.js.snap
@@ -14473,6 +14473,7 @@ exports[`EndpointForm component renders correctly 1`] = `
                                   className="j-api-form__section"
                                 >
                                   <OAuthEndpoints
+                                    activeTab={true}
                                     category="oauth_endpoints"
                                     change={[Function]}
                                     editing={false}
@@ -14825,6 +14826,7 @@ exports[`EndpointForm component renders correctly 1`] = `
                                   className="j-api-form__section"
                                 >
                                   <OAuthClientEndpoints
+                                    activeTab={false}
                                     category="oauth_client_endpoints"
                                     change={[Function]}
                                     editing={false}
@@ -29678,6 +29680,7 @@ exports[`EndpointForm component renders correctly if property \`editing\` is pas
                                   className="j-api-form__section"
                                 >
                                   <OAuthEndpoints
+                                    activeTab={true}
                                     category="oauth_endpoints"
                                     change={[Function]}
                                     editing={true}
@@ -30030,6 +30033,7 @@ exports[`EndpointForm component renders correctly if property \`editing\` is pas
                                   className="j-api-form__section"
                                 >
                                   <OAuthClientEndpoints
+                                    activeTab={false}
                                     category="oauth_client_endpoints"
                                     change={[Function]}
                                     editing={true}

--- a/src/components/AddDoubleFields/AddDoubleFields.js
+++ b/src/components/AddDoubleFields/AddDoubleFields.js
@@ -65,12 +65,7 @@ class AddDoubleFields extends PureComponent {
                                         component={Input}
                                         placeholder={config[1].placeholder}
                                         parse={this.passParse(config[1])}
-                                        validate={isValidate && checkOnPattern(isValidate)}
                                     />
-                                    {
-                                        warningMessage &&
-                                            <span className="j-input__warning">{warningMessage}</span>
-                                    }
                                 </div>
                                 <div className={row('control')()}>
                                     <Control

--- a/src/modules/pages/NewOAuthServerPage/OAuthServerForm.js
+++ b/src/modules/pages/NewOAuthServerPage/OAuthServerForm.js
@@ -67,6 +67,8 @@ class OAuthServerForm extends PureComponent {
         }), () => this.props.change('token_strategy', value.settings));
     };
 
+    isActiveTab = tabIndex => this.state.activeTab === tabIndex;
+
     renderTabs = () => (
         <div className={b('tabs')()}>
             <div className="j-buttons__wrapper tabs-nav">
@@ -74,7 +76,7 @@ class OAuthServerForm extends PureComponent {
                     this.state.tabs.map((item, idx) =>
                         <Button
                             key={item}
-                            mod={`${this.state.activeTab === idx ? 'primary' : 'white'}`}
+                            mod={`${this.isActiveTab(idx) ? 'primary' : 'white'}`}
                             onClick={() => this.handleTabSwitch(idx)}
                             type="button"
                         >
@@ -84,7 +86,7 @@ class OAuthServerForm extends PureComponent {
                 }
             </div>
 
-            <div className={b('tab', { hidden: this.state.activeTab !== 0 })()}>
+            <div className={b('tab', { hidden: !this.isActiveTab(0) })()}>
                 <div className={b('section')()}>
                     <OAuthEndpoints
                         editing={this.props.editing}
@@ -94,10 +96,11 @@ class OAuthServerForm extends PureComponent {
                         category={'oauth_endpoints'}
                         initialValues={this.props.initialValues}
                         strategyName={this.state.strategy.name}
+                        activeTab={this.isActiveTab(0)}
                     />
                 </div>
             </div>
-            <div className={b('tab', { hidden: this.state.activeTab !== 1 })()}>
+            <div className={b('tab', { hidden: !this.isActiveTab(1) })()}>
                 <div className={b('section')()}>
                     <OAuthClientEndpoints
                         editing={this.props.editing}
@@ -106,6 +109,7 @@ class OAuthServerForm extends PureComponent {
                         change={this.props.change}
                         category={'oauth_client_endpoints'}
                         initialValues={this.props.initialValues}
+                        activeTab={this.isActiveTab(1)}
                     />
                 </div>
             </div>

--- a/src/modules/pages/NewOAuthServerPage/partials/OAuthClientEndpoints/OAuthClientEndpoint.js
+++ b/src/modules/pages/NewOAuthServerPage/partials/OAuthClientEndpoints/OAuthClientEndpoint.js
@@ -25,6 +25,7 @@ const row = block('j-row');
 const col = block('j-col');
 
 const propTypes = {
+    activeTab: PropTypes.bool.isRequired,
     category: PropTypes.string.isRequired,
     change: PropTypes.func.isRequired,
     initialValues: PropTypes.object.isRequired,
@@ -69,18 +70,22 @@ class OAuthClientEndpoint extends PureComponent {
             case 'roundrobin': {
                 return (
                     <MultiRowField
+                        isValidate="url"
                         name={`${this.props.category}.${this.props.name}.upstreams.targets`}
                         suffix="target"
                         title="Targets"
                         placeholder="Target"
+                        warningMessage={WARNINGS.URL}
                     />
                 );
             }
             case 'weight': {
                 return (
                     <WeightTargets
+                        isValidate="url"
                         name={`${this.props.category}.${this.props.name}.upstreams.targets`}
                         title="Targets"
+                        warningMessage={WARNINGS.URL}
                     />
                 );
             }
@@ -90,7 +95,7 @@ class OAuthClientEndpoint extends PureComponent {
     };
 
     render() {
-        const { category, editing, name, schema } = this.props;
+        const { category, editing, name, schema, activeTab } = this.props;
 
         return (
             <div className={b('section')}>
@@ -124,7 +129,7 @@ class OAuthClientEndpoint extends PureComponent {
                                 onChange={this.handleChangeStrategy}
                                 value={this.state.upstreams.balancing}
                                 clearable={false}
-                                required
+                                required={activeTab}
                             />
                             <div className={row({fullwidth: true}).mix('j-api-form__row')}>
                                 <Row className={b('row')()} fullwidth>

--- a/src/modules/pages/NewOAuthServerPage/partials/OAuthClientEndpoints/OAuthClientEndpoints.js
+++ b/src/modules/pages/NewOAuthServerPage/partials/OAuthClientEndpoints/OAuthClientEndpoints.js
@@ -12,7 +12,7 @@ const propTypes = {
     schema: PropTypes.object.isRequired,
 };
 
-const OAuthClientEndpoints = ({ category, change, endpoints, initialValues, schema }) => {
+const OAuthClientEndpoints = ({ category, change, endpoints, initialValues, schema, activeTab }) => {
     const checkOnNil = item => !R.isNil(item);
     const endpointsList = R.toPairs(R.filter(checkOnNil, endpoints));
 
@@ -28,6 +28,7 @@ const OAuthClientEndpoints = ({ category, change, endpoints, initialValues, sche
                             change={change}
                             category={category}
                             initialValues={initialValues}
+                            activeTab={activeTab}
                         />
                     );
                 })

--- a/src/modules/pages/NewOAuthServerPage/partials/OAuthEndpoints/OAuthEndpoint.js
+++ b/src/modules/pages/NewOAuthServerPage/partials/OAuthEndpoints/OAuthEndpoint.js
@@ -26,6 +26,7 @@ const row = block('j-row');
 const col = block('j-col');
 
 const propTypes = {
+    activeTab: PropTypes.bool.isRequired,
     category: PropTypes.string.isRequired,
     change: PropTypes.func.isRequired,
     editing: PropTypes.bool,
@@ -73,8 +74,10 @@ class OAuthEndpoint extends PureComponent {
                     <MultiRowField
                         name={`${this.props.category}.${this.props.name}.upstreams.targets`}
                         placeholder="Target"
+                        isValidate="url"
                         suffix="target"
                         title="Targets"
+                        warningMessage={WARNINGS.URL}
                     />
                 );
             }
@@ -83,6 +86,8 @@ class OAuthEndpoint extends PureComponent {
                     <WeightTargets
                         name={`${this.props.category}.${this.props.name}.upstreams.targets`}
                         title="Targets"
+                        isValidate="url"
+                        warningMessage={WARNINGS.URL}
                     />
                 );
             }
@@ -92,7 +97,7 @@ class OAuthEndpoint extends PureComponent {
     };
 
     render() {
-        const { category, editing, initialValues, name, schema } = this.props;
+        const { category, editing, initialValues, name, schema, activeTab } = this.props;
 
         return (
             <div className={b('section')}>
@@ -126,7 +131,7 @@ class OAuthEndpoint extends PureComponent {
                                 onChange={this.handleChangeStrategy}
                                 value={this.state.upstreams.balancing}
                                 clearable={false}
-                                required
+                                required={activeTab}
                             />
                             <div className={row({fullwidth: true}).mix('j-api-form__row')}>
                                 <Row className={b('row')()} fullwidth>

--- a/src/modules/pages/NewOAuthServerPage/partials/OAuthEndpoints/OAuthEndpoints.js
+++ b/src/modules/pages/NewOAuthServerPage/partials/OAuthEndpoints/OAuthEndpoints.js
@@ -5,9 +5,10 @@ import R from 'ramda';
 import OAuthEndpoint from './OAuthEndpoint';
 
 const propTypes = {
+    activeTab: PropTypes.bool.isRequired,
     category: PropTypes.string.isRequired,
     change: PropTypes.func.isRequired,
-    editing: PropTypes.bool.isRequired,
+    editing: PropTypes.bool,
     endpoints: PropTypes.object.isRequired,
     initialValues: PropTypes.object.isRequired,
     schema: PropTypes.object.isRequired,
@@ -21,6 +22,7 @@ const OAuthEndpoints = ({
     initialValues,
     schema,
     strategyName,
+    activeTab,
 }) => {
     const checkOnNil = item => !R.isNil(item);
     const endpointsList = R.toPairs(R.filter(checkOnNil, endpoints));
@@ -38,6 +40,7 @@ const OAuthEndpoints = ({
             change={change}
             category={category}
             initialValues={initialValues}
+            activeTab={activeTab}
         />
     );
 


### PR DESCRIPTION
This **PR** removes `required` property from inactive tab on OAuthServer page.