### PR TITLE
Feature/use admin role to show hide info

### DIFF
--- a/src/__tests__/modules/EndpointForm/EndpointForm.test.js
+++ b/src/__tests__/modules/EndpointForm/EndpointForm.test.js
@@ -36,6 +36,7 @@ describe('EndpointForm component', () => {
         handleDelete: jest.fn(),
         handleSubmit: jest.fn(),
         initialValues,
+        isAdmin: false,
         selectPlugin: jest.fn(),
         selectedPlugins: ['a', 'b'],
     };
@@ -56,6 +57,27 @@ describe('EndpointForm component', () => {
         const passedProps = {
             api,
             editing: true,
+        };
+
+        const wrapper = mount(
+            renderFakeForm(store)(initialValues)(
+                <MemoryRouter>
+                    <EndpointForm
+                        {...requiredProps}
+                        {...passedProps}
+                    />
+                </MemoryRouter>
+            )
+        );
+
+        expect(wrapper.find('.j-buttons__wrapper')).toMatchSnapshot();
+    });
+
+    it('renders correctly if property logged user has admin role', () => {
+        const passedProps = {
+            api,
+            editing: true,
+            isAdmin: true,
         };
 
         const wrapper = mount(

--- a/src/__tests__/modules/EndpointForm/__snapshots__/EndpointForm.test.js.snap
+++ b/src/__tests__/modules/EndpointForm/__snapshots__/EndpointForm.test.js.snap
@@ -351,6 +351,7 @@ exports[`EndpointForm component renders correctly 1`] = `
                   },
                 }
               }
+              isAdmin={false}
               name="mock-name"
               selectPlugin={[Function]}
               selectedPlugins={
@@ -528,6 +529,7 @@ exports[`EndpointForm component renders correctly 1`] = `
                     },
                   }
                 }
+                isAdmin={false}
                 keepDirtyOnReinitialize={false}
                 name="mock-name"
                 selectPlugin={[Function]}
@@ -711,6 +713,7 @@ exports[`EndpointForm component renders correctly 1`] = `
                       },
                     }
                   }
+                  isAdmin={false}
                   keepDirtyOnReinitialize={false}
                   name="mock-name"
                   persistentSubmitErrors={false}
@@ -938,6 +941,7 @@ exports[`EndpointForm component renders correctly 1`] = `
                     initialize={[Function]}
                     initialized={false}
                     invalid={false}
+                    isAdmin={false}
                     keepDirtyOnReinitialize={false}
                     name="mock-name"
                     persistentSubmitErrors={false}
@@ -1180,6 +1184,7 @@ exports[`EndpointForm component renders correctly 1`] = `
                       initialize={[Function]}
                       initialized={false}
                       invalid={false}
+                      isAdmin={false}
                       name="mock-name"
                       pristine={true}
                       pure={true}
@@ -1541,6 +1546,7 @@ exports[`EndpointForm component renders correctly 1`] = `
                                             "initialize": [Function],
                                             "initialized": false,
                                             "invalid": false,
+                                            "isAdmin": false,
                                             "keepDirtyOnReinitialize": false,
                                             "name": "mock-name",
                                             "persistentSubmitErrors": false,
@@ -1810,6 +1816,7 @@ exports[`EndpointForm component renders correctly 1`] = `
                                               "initialize": [Function],
                                               "initialized": false,
                                               "invalid": false,
+                                              "isAdmin": false,
                                               "keepDirtyOnReinitialize": false,
                                               "name": "mock-name",
                                               "persistentSubmitErrors": false,
@@ -2203,6 +2210,7 @@ exports[`EndpointForm component renders correctly 1`] = `
                                                             "initialize": [Function],
                                                             "initialized": false,
                                                             "invalid": false,
+                                                            "isAdmin": false,
                                                             "keepDirtyOnReinitialize": false,
                                                             "name": "mock-name",
                                                             "persistentSubmitErrors": false,
@@ -2471,6 +2479,7 @@ exports[`EndpointForm component renders correctly 1`] = `
                                                               "initialize": [Function],
                                                               "initialized": false,
                                                               "invalid": false,
+                                                              "isAdmin": false,
                                                               "keepDirtyOnReinitialize": false,
                                                               "name": "mock-name",
                                                               "persistentSubmitErrors": false,
@@ -2868,6 +2877,7 @@ exports[`EndpointForm component renders correctly 1`] = `
                                                             "initialize": [Function],
                                                             "initialized": false,
                                                             "invalid": false,
+                                                            "isAdmin": false,
                                                             "keepDirtyOnReinitialize": false,
                                                             "name": "mock-name",
                                                             "persistentSubmitErrors": false,
@@ -3136,6 +3146,7 @@ exports[`EndpointForm component renders correctly 1`] = `
                                                               "initialize": [Function],
                                                               "initialized": false,
                                                               "invalid": false,
+                                                              "isAdmin": false,
                                                               "keepDirtyOnReinitialize": false,
                                                               "name": "mock-name",
                                                               "persistentSubmitErrors": false,
@@ -3562,6 +3573,7 @@ exports[`EndpointForm component renders correctly 1`] = `
                                             "initialize": [Function],
                                             "initialized": false,
                                             "invalid": false,
+                                            "isAdmin": false,
                                             "keepDirtyOnReinitialize": false,
                                             "name": "mock-name",
                                             "persistentSubmitErrors": false,
@@ -3831,6 +3843,7 @@ exports[`EndpointForm component renders correctly 1`] = `
                                               "initialize": [Function],
                                               "initialized": false,
                                               "invalid": false,
+                                              "isAdmin": false,
                                               "keepDirtyOnReinitialize": false,
                                               "name": "mock-name",
                                               "persistentSubmitErrors": false,
@@ -4456,6 +4469,7 @@ exports[`EndpointForm component renders correctly 1`] = `
                                                 "initialize": [Function],
                                                 "initialized": false,
                                                 "invalid": false,
+                                                "isAdmin": false,
                                                 "keepDirtyOnReinitialize": false,
                                                 "name": "mock-name",
                                                 "persistentSubmitErrors": false,
@@ -4765,6 +4779,7 @@ exports[`EndpointForm component renders correctly 1`] = `
                                                   "initialize": [Function],
                                                   "initialized": false,
                                                   "invalid": false,
+                                                  "isAdmin": false,
                                                   "keepDirtyOnReinitialize": false,
                                                   "name": "mock-name",
                                                   "persistentSubmitErrors": false,
@@ -5423,6 +5438,7 @@ exports[`EndpointForm component renders correctly 1`] = `
                                                 "initialize": [Function],
                                                 "initialized": false,
                                                 "invalid": false,
+                                                "isAdmin": false,
                                                 "keepDirtyOnReinitialize": false,
                                                 "name": "mock-name",
                                                 "persistentSubmitErrors": false,
@@ -5692,6 +5708,7 @@ exports[`EndpointForm component renders correctly 1`] = `
                                                   "initialize": [Function],
                                                   "initialized": false,
                                                   "invalid": false,
+                                                  "isAdmin": false,
                                                   "keepDirtyOnReinitialize": false,
                                                   "name": "mock-name",
                                                   "persistentSubmitErrors": false,
@@ -6301,6 +6318,7 @@ exports[`EndpointForm component renders correctly 1`] = `
                                                             "initialize": [Function],
                                                             "initialized": false,
                                                             "invalid": false,
+                                                            "isAdmin": false,
                                                             "keepDirtyOnReinitialize": false,
                                                             "name": "mock-name",
                                                             "persistentSubmitErrors": false,
@@ -6569,6 +6587,7 @@ exports[`EndpointForm component renders correctly 1`] = `
                                                               "initialize": [Function],
                                                               "initialized": false,
                                                               "invalid": false,
+                                                              "isAdmin": false,
                                                               "keepDirtyOnReinitialize": false,
                                                               "name": "mock-name",
                                                               "persistentSubmitErrors": false,
@@ -6966,6 +6985,7 @@ exports[`EndpointForm component renders correctly 1`] = `
                                                             "initialize": [Function],
                                                             "initialized": false,
                                                             "invalid": false,
+                                                            "isAdmin": false,
                                                             "keepDirtyOnReinitialize": false,
                                                             "name": "mock-name",
                                                             "persistentSubmitErrors": false,
@@ -7234,6 +7254,7 @@ exports[`EndpointForm component renders correctly 1`] = `
                                                               "initialize": [Function],
                                                               "initialized": false,
                                                               "invalid": false,
+                                                              "isAdmin": false,
                                                               "keepDirtyOnReinitialize": false,
                                                               "name": "mock-name",
                                                               "persistentSubmitErrors": false,
@@ -7681,6 +7702,7 @@ exports[`EndpointForm component renders correctly 1`] = `
                                                             "initialize": [Function],
                                                             "initialized": false,
                                                             "invalid": false,
+                                                            "isAdmin": false,
                                                             "keepDirtyOnReinitialize": false,
                                                             "name": "mock-name",
                                                             "persistentSubmitErrors": false,
@@ -7949,6 +7971,7 @@ exports[`EndpointForm component renders correctly 1`] = `
                                                               "initialize": [Function],
                                                               "initialized": false,
                                                               "invalid": false,
+                                                              "isAdmin": false,
                                                               "keepDirtyOnReinitialize": false,
                                                               "name": "mock-name",
                                                               "persistentSubmitErrors": false,
@@ -8346,6 +8369,7 @@ exports[`EndpointForm component renders correctly 1`] = `
                                                             "initialize": [Function],
                                                             "initialized": false,
                                                             "invalid": false,
+                                                            "isAdmin": false,
                                                             "keepDirtyOnReinitialize": false,
                                                             "name": "mock-name",
                                                             "persistentSubmitErrors": false,
@@ -8614,6 +8638,7 @@ exports[`EndpointForm component renders correctly 1`] = `
                                                               "initialize": [Function],
                                                               "initialized": false,
                                                               "invalid": false,
+                                                              "isAdmin": false,
                                                               "keepDirtyOnReinitialize": false,
                                                               "name": "mock-name",
                                                               "persistentSubmitErrors": false,
@@ -9070,6 +9095,7 @@ exports[`EndpointForm component renders correctly 1`] = `
                                                             "initialize": [Function],
                                                             "initialized": false,
                                                             "invalid": false,
+                                                            "isAdmin": false,
                                                             "keepDirtyOnReinitialize": false,
                                                             "name": "mock-name",
                                                             "persistentSubmitErrors": false,
@@ -9338,6 +9364,7 @@ exports[`EndpointForm component renders correctly 1`] = `
                                                               "initialize": [Function],
                                                               "initialized": false,
                                                               "invalid": false,
+                                                              "isAdmin": false,
                                                               "keepDirtyOnReinitialize": false,
                                                               "name": "mock-name",
                                                               "persistentSubmitErrors": false,
@@ -9735,6 +9762,7 @@ exports[`EndpointForm component renders correctly 1`] = `
                                                             "initialize": [Function],
                                                             "initialized": false,
                                                             "invalid": false,
+                                                            "isAdmin": false,
                                                             "keepDirtyOnReinitialize": false,
                                                             "name": "mock-name",
                                                             "persistentSubmitErrors": false,
@@ -10003,6 +10031,7 @@ exports[`EndpointForm component renders correctly 1`] = `
                                                               "initialize": [Function],
                                                               "initialized": false,
                                                               "invalid": false,
+                                                              "isAdmin": false,
                                                               "keepDirtyOnReinitialize": false,
                                                               "name": "mock-name",
                                                               "persistentSubmitErrors": false,
@@ -10446,6 +10475,7 @@ exports[`EndpointForm component renders correctly 1`] = `
                                             "initialize": [Function],
                                             "initialized": false,
                                             "invalid": false,
+                                            "isAdmin": false,
                                             "keepDirtyOnReinitialize": false,
                                             "name": "mock-name",
                                             "persistentSubmitErrors": false,
@@ -10714,6 +10744,7 @@ exports[`EndpointForm component renders correctly 1`] = `
                                               "initialize": [Function],
                                               "initialized": false,
                                               "invalid": false,
+                                              "isAdmin": false,
                                               "keepDirtyOnReinitialize": false,
                                               "name": "mock-name",
                                               "persistentSubmitErrors": false,
@@ -11083,6 +11114,7 @@ exports[`EndpointForm component renders correctly 1`] = `
                                                 "initialize": [Function],
                                                 "initialized": false,
                                                 "invalid": false,
+                                                "isAdmin": false,
                                                 "keepDirtyOnReinitialize": false,
                                                 "name": "mock-name",
                                                 "persistentSubmitErrors": false,
@@ -11350,6 +11382,7 @@ exports[`EndpointForm component renders correctly 1`] = `
                                                   "initialize": [Function],
                                                   "initialized": false,
                                                   "invalid": false,
+                                                  "isAdmin": false,
                                                   "keepDirtyOnReinitialize": false,
                                                   "name": "mock-name",
                                                   "persistentSubmitErrors": false,
@@ -11522,6 +11555,61 @@ exports[`EndpointForm component renders correctly 1`] = `
 `;
 
 exports[`EndpointForm component renders correctly if property \`editing\` is passed 1`] = `
+<div
+  className="j-buttons__wrapper"
+>
+  <Button
+    mod="primary"
+    type="submit"
+  >
+    <button
+      className="j-button j-button--primary"
+      type="submit"
+    >
+      Save
+    </button>
+  </Button>
+  <Link
+    replace={false}
+    to={
+      Object {
+        "pathname": "/new",
+        "state": Object {
+          "clone": Object {
+            "name": "mock-api",
+          },
+        },
+      }
+    }
+  >
+    <a
+      href="/new"
+      onClick={[Function]}
+    >
+      <Button
+        mod="primary"
+        type="button"
+      >
+        <button
+          className="j-button j-button--primary"
+          type="button"
+        >
+          <Icon
+            type="copy-white"
+          >
+            <span
+              className="j-icon j-icon--type-copy-white"
+            />
+          </Icon>
+          Copy
+        </button>
+      </Button>
+    </a>
+  </Link>
+</div>
+`;
+
+exports[`EndpointForm component renders correctly if property logged user has admin role 1`] = `
 <div
   className="j-buttons__wrapper"
 >

--- a/src/__tests__/store/reducers/userSession.reducer.test.js
+++ b/src/__tests__/store/reducers/userSession.reducer.test.js
@@ -67,6 +67,7 @@ describe('user session reducer', () => {
 
         it('sets correct user info and admin status, and discard errorMsg to null when user getes logged in', () => {
             expect(result.user).toEqual('mock-name');
+            expect(result.isAdmin).toEqual(false);
             expect(result.errorMsg).toEqual(null);
         });
 
@@ -93,7 +94,7 @@ describe('user session reducer', () => {
 
         it('discards user info and status, and sets the error message to the given payload when user failed to log in', () => {
             expect(result.user).toEqual('');
-            expect(result.isAdmin).toEqual(null);
+            expect(result.isAdmin).toEqual(false);
             expect(result.errorMsg).toEqual(payload);
         });
 
@@ -112,7 +113,7 @@ describe('user session reducer', () => {
         });
 
         it('discards admin status', () => {
-            expect(result.isAdmin).toBe(null);
+            expect(result.isAdmin).toBe(false);
         });
 
         it('has only change exact amount of reducer properties', () => {

--- a/src/__tests__/store/reducers/userSession.reducer.test.js
+++ b/src/__tests__/store/reducers/userSession.reducer.test.js
@@ -58,22 +58,29 @@ describe('user session reducer', () => {
             {},
             {
                 type: LOGIN_SUCCESS,
-                payload: true,
+                payload: {
+                    userName: 'mock-name',
+                    isAdmin: false,
+                },
             }
         );
 
-        it('sets the user info and errorMsg to null when user getes logged in', () => {
-            expect(result.user).toEqual(true);
+        it('sets correct user info and admin status, and discard errorMsg to null when user getes logged in', () => {
+            expect(result.user).toEqual('mock-name');
             expect(result.errorMsg).toEqual(null);
         });
 
         it('has only change exact amount of reducer properties', () => {
-            expect(touchedReducerProps(result)).toBe(2);
+            expect(touchedReducerProps(result)).toBe(3);
         });
     });
 
     describe('LOGIN_FAILURE', () => {
-        const initialState = { user: {name: 'User'}, errorMsg: null };
+        const initialState = {
+            user: 'mock-name',
+            isAdmin: false,
+            errorMsg: null,
+        };
         const payload = 'an-error-message';
 
         const result = userSessionReducer(
@@ -84,13 +91,14 @@ describe('user session reducer', () => {
             }
         );
 
-        it('sets the logged state to false and the error message to the given payload when user failed to log in', () => {
+        it('discards user info and status, and sets the error message to the given payload when user failed to log in', () => {
             expect(result.user).toEqual('');
+            expect(result.isAdmin).toEqual(null);
             expect(result.errorMsg).toEqual(payload);
         });
 
         it('has only change exact amount of reducer properties', () => {
-            expect(touchedReducerProps(result)).toBe(2);
+            expect(touchedReducerProps(result)).toBe(3);
         });
     });
 
@@ -103,8 +111,12 @@ describe('user session reducer', () => {
             expect(result.user).toBe('');
         });
 
+        it('discards admin status', () => {
+            expect(result.isAdmin).toBe(null);
+        });
+
         it('has only change exact amount of reducer properties', () => {
-            expect(touchedReducerProps(result)).toBe(1);
+            expect(touchedReducerProps(result)).toBe(2);
         });
     });
 });

--- a/src/modules/forms/EndpointForm/EndpointForm.js
+++ b/src/modules/forms/EndpointForm/EndpointForm.js
@@ -48,6 +48,7 @@ const propTypes = {
     handleDelete: PropTypes.func.isRequired,
     handleSubmit: PropTypes.func.isRequired,
     initialValues: PropTypes.object,
+    isAdmin: PropTypes.bool.isRequired,
     selectPlugin: PropTypes.func.isRequired,
     selectedPlugins: PropTypes.arrayOf(PropTypes.string).isRequired,
 };
@@ -147,14 +148,17 @@ class EndpointForm extends PureComponent {
                             Copy
                         </Button>
                     </Link>
-                    <Button
-                        type="button"
-                        mod="danger"
-                        onClick={this.props.handleDelete}
-                    >
-                        <Icon type="delete-white" />
-                        Delete
-                    </Button>
+                    {
+                        this.props.isAdmin &&
+                            <Button
+                                type="button"
+                                mod="danger"
+                                onClick={this.props.handleDelete}
+                            >
+                                <Icon type="delete-white" />
+                                Delete
+                            </Button>
+                    }
                 </div>
             );
         }

--- a/src/modules/pages/ApiListPage/ApiList.js
+++ b/src/modules/pages/ApiListPage/ApiList.js
@@ -18,6 +18,7 @@ import '../../Layout/Table/Table.css';
 const propTypes = {
     apiList: PropTypes.arrayOf(PropTypes.object.isRequired).isRequired,
     currentPageIndex: PropTypes.number.isRequired,
+    isAdmin: PropTypes.bool.isRequired,
     setCurrentPageIndex: PropTypes.func.isRequired,
     deleteEndpoint: PropTypes.func.isRequired,
     fetchEndpoints: PropTypes.func.isRequired,
@@ -69,13 +70,16 @@ class ApiList extends PureComponent {
                 >
                     <Icon type="copy" ariaLabel="Copy" />
                 </Link>
-                <Control
-                    className={table('controls-item')()}
-                    icon="delete"
-                    onClick={() => {
-                        this.handleDelete(api);
-                    }}
-                />
+                {
+                    this.props.isAdmin &&
+                    <Control
+                        className={table('controls-item')()}
+                        icon="delete"
+                        onClick={() => {
+                            this.handleDelete(api);
+                        }}
+                    />
+                }
             </div>
         </div>
     ))

--- a/src/modules/pages/ApiListPage/apiListContainer.js
+++ b/src/modules/pages/ApiListPage/apiListContainer.js
@@ -16,6 +16,7 @@ const mapStateToProps = state => ({
     apiList: filteredApiList(state),
     currentPageIndex: state.paginationReducer.currentPageIndex,
     searchQuery: state.searchReducer.searchQuery,
+    isAdmin: state.userSessionReducer.isAdmin,
 });
 
 export default connect(

--- a/src/modules/pages/EditPage/ApiItem.js
+++ b/src/modules/pages/EditPage/ApiItem.js
@@ -15,6 +15,7 @@ const propTypes = {
     excludePlugin: PropTypes.func.isRequired,
     fetchEndpointSchema: PropTypes.func.isRequired,
     fillSelected: PropTypes.func.isRequired,
+    isAdmin: PropTypes.bool,
     selectPlugin: PropTypes.func.isRequired,
     fetchEndpoint: PropTypes.func.isRequired,
     refreshEndpoints: PropTypes.func.isRequired,
@@ -74,6 +75,7 @@ class ApiItem extends PureComponent {
                 excludePlugin={this.props.excludePlugin}
                 handleDelete={this.handleDelete}
                 initialValues={transformFormValues(updatedApi)}
+                isAdmin={this.props.isAdmin}
                 onSubmit={this.submit}
                 selectPlugin={this.props.selectPlugin}
                 selectedPlugins={this.props.selectedPlugins}

--- a/src/modules/pages/EditPage/editApiContainer.js
+++ b/src/modules/pages/EditPage/editApiContainer.js
@@ -20,6 +20,7 @@ const mapStateToProps = state => ({
     apiSchema: state.apiReducer.apiSchema,
     response: state.apiReducer.response,
     selectedPlugins: state.apiReducer.selectedPlugins,
+    isAdmin: state.userSessionReducer.isAdmin,
 });
 
 export default connect(

--- a/src/modules/pages/OAuthServersPage/OAuthServersList.js
+++ b/src/modules/pages/OAuthServersPage/OAuthServersList.js
@@ -21,6 +21,7 @@ const propTypes = {
     currentPageIndex: PropTypes.number.isRequired,
     deleteOAuthServer: PropTypes.func.isRequired,
     fetchOAuthServers: PropTypes.func.isRequired,
+    isAdmin: PropTypes.bool.isRequired,
     oAuthServers: PropTypes.arrayOf(PropTypes.object).isRequired,
     setAscendingFilter: PropTypes.func.isRequired,
     setCurrentPageIndex: PropTypes.func.isRequired,
@@ -53,13 +54,16 @@ class OAuthServersList extends PureComponent {
                 <Link to={`${ROUTES.OAUTH_SERVERS.path}/${server.name}`} className={table('controls-item')}>
                     <Icon type="edit" ariaLabel="Edit" />
                 </Link>
-                <Control
-                    className={table('controls-item')()}
-                    icon="delete"
-                    onClick={() => {
-                        this.handleDelete(server);
-                    }}
-                />
+                {
+                    this.props.isAdmin &&
+                        <Control
+                            className={table('controls-item')()}
+                            icon="delete"
+                            onClick={() => {
+                                this.handleDelete(server);
+                            }}
+                        />
+                }
             </div>
         </div>
     ))

--- a/src/modules/pages/OAuthServersPage/oAuthServersContainer.js
+++ b/src/modules/pages/OAuthServersPage/oAuthServersContainer.js
@@ -15,6 +15,7 @@ const mapStateToProps = state => ({
     oAuthServers: filteredOAuthServersList(state),
     currentPageIndex: state.paginationReducer.currentPageIndex,
     searchQuery: state.searchReducer.searchQuery,
+    isAdmin: state.userSessionReducer.isAdmin,
 });
 
 export default connect(

--- a/src/store/actions/userSession.actions.js
+++ b/src/store/actions/userSession.actions.js
@@ -86,9 +86,12 @@ export const loginRequest = () => ({
     type: LOGIN_START,
 });
 
-export const loginSuccess = userName => ({
+export const loginSuccess = (userName, isAdmin) => ({
     type: LOGIN_SUCCESS,
-    payload: userName,
+    payload: {
+        userName,
+        isAdmin,
+    },
 });
 
 export const loginFailure = () => ({
@@ -114,8 +117,18 @@ export const getUserStatus = () => dispatch => {
     const JWTtoken = getAccessToken();
 
     if (JWTtoken) {
-        dispatch(loginSuccess(jwt.decode(JWTtoken).sub));
+        dispatch(loginSuccess(
+            getUserName(JWTtoken),
+            getUserAdminRole(JWTtoken),
+        ));
     } else {
         history.push('/login');
     }
 };
+
+function getUserName(JWTtoken) {
+    return jwt.decode(JWTtoken).sub;
+}
+function getUserAdminRole(JWTtoken) {
+    return jwt.decode(JWTtoken).is_admin;
+}

--- a/src/store/reducers/userSession.reducer.js
+++ b/src/store/reducers/userSession.reducer.js
@@ -8,6 +8,7 @@ import {
 
 export const initialState = {
     errorMsg: null,
+    isAdmin: null,
     user: '',
 };
 
@@ -24,7 +25,8 @@ export default function reducer(state = initialState, action) {
             return {
                 ...state,
                 errorMsg: null,
-                user: action.payload,
+                user: action.payload.userName,
+                isAdmin: action.payload.isAdmin,
             };
         }
 
@@ -33,6 +35,7 @@ export default function reducer(state = initialState, action) {
                 ...state,
                 errorMsg: action.payload,
                 user: '',
+                isAdmin: null,
             };
         }
 
@@ -40,6 +43,7 @@ export default function reducer(state = initialState, action) {
             return {
                 ...state,
                 user: '',
+                isAdmin: null,
             };
         }
 

--- a/src/store/reducers/userSession.reducer.js
+++ b/src/store/reducers/userSession.reducer.js
@@ -8,7 +8,7 @@ import {
 
 export const initialState = {
     errorMsg: null,
-    isAdmin: null,
+    isAdmin: false,
     user: '',
 };
 
@@ -35,7 +35,7 @@ export default function reducer(state = initialState, action) {
                 ...state,
                 errorMsg: action.payload,
                 user: '',
-                isAdmin: null,
+                isAdmin: false,
             };
         }
 
@@ -43,7 +43,7 @@ export default function reducer(state = initialState, action) {
             return {
                 ...state,
                 user: '',
-                isAdmin: null,
+                isAdmin: false,
             };
         }
 


### PR DESCRIPTION
This **PR** uses `isAdmin` to show/display _delete_ buttons.