### PR TITLE
Remove redundant stuff from api endpoint preview

### DIFF
--- a/src/modules/forms/EndpointForm/EndpointForm.js
+++ b/src/modules/forms/EndpointForm/EndpointForm.js
@@ -36,6 +36,8 @@ import MultiRowField from '../../../components/MultiRowField/MultiRowField'
 import WeightTargets from '../../pages/NewApiPage/partials/WeightTargets/WeightTargets'
 import JSONmodal from '../../modals/JSONmodal/JSONmodal'
 
+import { getUpdatedEndpoint } from '../../../store/actions'
+
 import './EndpointForm.css'
 
 const b = block('j-api-form')
@@ -165,7 +167,7 @@ class EndpointForm extends PureComponent {
             onClick={() => {
               this.setState({
                 showJSONmodal: true,
-                JSONmodalContent: this.props.api
+                JSONmodalContent: getUpdatedEndpoint(this.props.api)
               })
             }}
           >
@@ -175,7 +177,7 @@ class EndpointForm extends PureComponent {
             key='download'
             mod='primary'
             type='button'
-            onClick={() => downloadObjectAsJson(this.props.api, this.props.api.name)}
+            onClick={() => downloadObjectAsJson(getUpdatedEndpoint(this.props.api), this.props.api.name)}
           >
             Download
           </Button>

--- a/src/modules/forms/EndpointForm/EndpointForm.js
+++ b/src/modules/forms/EndpointForm/EndpointForm.js
@@ -139,6 +139,8 @@ class EndpointForm extends PureComponent {
     }
   };
 
+  getEndpoint = () => getUpdatedEndpoint(this.props.api)
+
   renderStickyButtons = () => {
     if (this.props.editing && this.props.api.name) {
       return (
@@ -167,7 +169,7 @@ class EndpointForm extends PureComponent {
             onClick={() => {
               this.setState({
                 showJSONmodal: true,
-                JSONmodalContent: getUpdatedEndpoint(this.props.api)
+                JSONmodalContent: this.getEndpoint()
               })
             }}
           >
@@ -177,7 +179,7 @@ class EndpointForm extends PureComponent {
             key='download'
             mod='primary'
             type='button'
-            onClick={() => downloadObjectAsJson(getUpdatedEndpoint(this.props.api), this.props.api.name)}
+            onClick={() => downloadObjectAsJson(this.getEndpoint(), this.props.api.name)}
           >
             Download
           </Button>

--- a/src/store/actions/api.actions.js
+++ b/src/store/actions/api.actions.js
@@ -344,16 +344,22 @@ export const confirmedSaveEndpoint = async (dispatch, api) => {
   }
 }
 
-export const confirmedUpdateEndpoint = async (dispatch, api) => {
-  dispatch(saveEndpointRequest())
-  dispatch(closeConfirmationModal())
-
-  // substitude updated list of plugins
+export const getUpdatedEndpoint = api => {
   const prepareApi = R.set(R.lensPath(['plugins']), R.__, api)
   const updatedEndpoint = R.compose(
     prepareApi,
     preparePlugins
   )(api)
+
+  return updatedEndpoint
+}
+
+export const confirmedUpdateEndpoint = async (dispatch, api) => {
+  dispatch(saveEndpointRequest())
+  dispatch(closeConfirmationModal())
+
+  // substitude updated list of plugins
+  const updatedEndpoint = getUpdatedEndpoint(api)
 
   try {
     await client.put(`apis/${api.name}`, updatedEndpoint)


### PR DESCRIPTION
## What this PR does?

This **PR** removes redundant info from api enpoint preview (before there were options from schema, which were further removing during the PUT process).
