### PR TITLE
Fix an updating of the endpoint state after options were changed

### DIFF
--- a/src/modules/forms/EndpointForm/EndpointForm.js
+++ b/src/modules/forms/EndpointForm/EndpointForm.js
@@ -16,6 +16,7 @@ import parse from '../../../helpers/parse-value'
 import optionsTransformer from '../../../helpers/optionsTransformer'
 import getValues from '../../../helpers/getValues'
 import downloadObjectAsJson from '../../../helpers/downloadObjectAsJson'
+import getUpdatedEndpoint from '../../../helpers/getUpdatedEndpoint'
 
 import Section from '../../Layout/Section/Section'
 import Title from '../../Layout/Title/Title'
@@ -36,7 +37,7 @@ import MultiRowField from '../../../components/MultiRowField/MultiRowField'
 import WeightTargets from '../../pages/NewApiPage/partials/WeightTargets/WeightTargets'
 import JSONmodal from '../../modals/JSONmodal/JSONmodal'
 
-import { getUpdatedEndpoint } from '../../../store/actions'
+import { createUpdatedEndpoint } from '../../../store/actions'
 
 import './EndpointForm.css'
 
@@ -103,6 +104,8 @@ class EndpointForm extends PureComponent {
     JSONmodalContent: {}
   })
 
+  handleGetUpdatedConfiguration = () => getUpdatedEndpoint(createUpdatedEndpoint(this.props.allFormValues))(this.props.selectedPlugins)
+
   renderSaveButton = () => <Button
     type='submit'
     mod='primary'
@@ -137,9 +140,7 @@ class EndpointForm extends PureComponent {
       default:
         return null
     }
-  };
-
-  getEndpoint = () => getUpdatedEndpoint(this.props.api)
+  }
 
   renderStickyButtons = () => {
     if (this.props.editing && this.props.api.name) {
@@ -169,7 +170,7 @@ class EndpointForm extends PureComponent {
             onClick={() => {
               this.setState({
                 showJSONmodal: true,
-                JSONmodalContent: this.getEndpoint()
+                JSONmodalContent: this.handleGetUpdatedConfiguration()
               })
             }}
           >
@@ -179,7 +180,7 @@ class EndpointForm extends PureComponent {
             key='download'
             mod='primary'
             type='button'
-            onClick={() => downloadObjectAsJson(this.getEndpoint(), this.props.api.name)}
+            onClick={() => downloadObjectAsJson(this.handleGetUpdatedConfiguration(), this.props.api.name)}
           >
             Download
           </Button>
@@ -501,10 +502,12 @@ const form = reduxForm({
 export default connect(
   state => {
     const plugins = selector(state, 'plugins')
+    const allFormValues = selector(state, 'name', 'active', 'health_check', 'proxy', 'plugins')
 
     return {
       keepDirtyOnReinitialize: false,
-      plugins
+      plugins,
+      allFormValues
     }
   },
   null

--- a/src/store/actions/api.actions.js
+++ b/src/store/actions/api.actions.js
@@ -344,7 +344,7 @@ export const confirmedSaveEndpoint = async (dispatch, api) => {
   }
 }
 
-export const getUpdatedEndpoint = api => {
+export const createUpdatedEndpoint = api => {
   const prepareApi = R.set(R.lensPath(['plugins']), R.__, api)
   const updatedEndpoint = R.compose(
     prepareApi,
@@ -359,7 +359,7 @@ export const confirmedUpdateEndpoint = async (dispatch, api) => {
   dispatch(closeConfirmationModal())
 
   // substitude updated list of plugins
-  const updatedEndpoint = getUpdatedEndpoint(api)
+  const updatedEndpoint = createUpdatedEndpoint(api)
 
   try {
     await client.put(`apis/${api.name}`, updatedEndpoint)


### PR DESCRIPTION
## What this PR does?

Previously, when the user was updating the configuration of the endpoint and later was clicking `Copy as JSON` he was able to see the only previous version of the endpoint. Now this issue is fixed.

[JIRA ticket](https://hellofresh.atlassian.net/browse/PT-620)