### PR TITLE
Fix use_oauth_header key name

### DIFF
--- a/src/__tests__/modules/OAuthServerForm/__snapshots__/OAuthServerForm.test.js.snap
+++ b/src/__tests__/modules/OAuthServerForm/__snapshots__/OAuthServerForm.test.js.snap
@@ -335,7 +335,7 @@ exports[`EndpointForm component renders correctly 1`] = `
               "name": "introspection",
               "settings": Object {
                 "auth_header_type": "",
-                "use_oauth_header": false,
+                "use_auth_header": false,
               },
             },
           ],
@@ -681,7 +681,7 @@ exports[`EndpointForm component renders correctly if property \`editing\` is pas
               "name": "introspection",
               "settings": Object {
                 "auth_header_type": "",
-                "use_oauth_header": false,
+                "use_auth_header": false,
               },
             },
           ],

--- a/src/configurations/oAuthServerSchema.config.js
+++ b/src/configurations/oAuthServerSchema.config.js
@@ -245,7 +245,7 @@ const oAuthServerSchema = {
       {
         name: 'introspection',
         settings: {
-          use_oauth_header: false,
+          use_auth_header: false,
           auth_header_type: ''
         }
       }

--- a/src/modules/pages/NewOAuthServerPage/OAuthServerForm.js
+++ b/src/modules/pages/NewOAuthServerPage/OAuthServerForm.js
@@ -178,7 +178,7 @@ class OAuthServerForm extends PureComponent {
             <Row className={b('radio-wrap')()}>
               <Row className={b('radio')()}>
                 <Field
-                  name='token_strategy.settings.use_oauth_header'
+                  name='token_strategy.settings.use_auth_header'
                   component={Radio}
                   value={'true'}
                   type='radio'
@@ -188,7 +188,7 @@ class OAuthServerForm extends PureComponent {
               </Row>
               <Row className={b('radio')()}>
                 <Field
-                  name='token_strategy.settings.use_oauth_header'
+                  name='token_strategy.settings.use_auth_header'
                   component={Radio}
                   value={'false'}
                   type='radio'


### PR DESCRIPTION
#### Description
It should be `use_auth_header`
https://github.com/hellofresh/janus/blob/cf6259d7fd81c2efeeb1685d23add522704e0081/pkg/plugin/oauth2/oauth.go#L71

#### Ticket
None