### PR TITLE
Update nginx version tag in Dockerfile to stable-alpine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ script:
     --network="host"
     cypress/browsers:chrome65-ff57
     /bin/sh -c
-    '$(npm bin)/cypress run --headed'
+    '$(npm bin)/cypress run --browser chrome'
 
 after_script:
   - docker-compose -f tests/docker-compose.test.yml down

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN npm run build
 
 # -----
 
-FROM nginx:1.12-alpine
+FROM nginx:stable-alpine
 MAINTAINER HelloFresh
 COPY --from=builder /app/src/default.conf /etc/nginx/conf.d/default.conf
 COPY --from=builder /app/build/ /usr/share/nginx/html/


### PR DESCRIPTION
Fixes [CVE-2017-16931][1] shown in quay.io [vulnerability scan][2].

[1]: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-16931
[2]: https://quay.io/repository/hellofresh/janus-dashboard/manifest/sha256:e56e26c9055e79d5e2af49f3c616b3745f7c8ceff9df1cb526ecddc457a49d9f?tab=vulnerabilities