### PR TITLE
Remove ALL method from OAuth CORS options

### DIFF
--- a/src/configurations/oAuthServerSchema.config.js
+++ b/src/configurations/oAuthServerSchema.config.js
@@ -33,7 +33,7 @@ const oAuthServerSchema = {
       append_path: false,
       enable_load_balancing: false,
       methods: [],
-      all_methods: ['ALL', 'CONNECT', 'DELETE', 'GET', 'HEAD', 'OPTIONS', 'POST', 'PUT', 'PATCH'],
+      all_methods: ['CONNECT', 'DELETE', 'GET', 'HEAD', 'OPTIONS', 'POST', 'PUT', 'PATCH'],
       hosts: []
     },
     token: {
@@ -68,7 +68,7 @@ const oAuthServerSchema = {
       append_path: false,
       enable_load_balancing: false,
       methods: [],
-      all_methods: ['ALL', 'CONNECT', 'DELETE', 'GET', 'HEAD', 'OPTIONS', 'POST', 'PUT', 'PATCH'],
+      all_methods: ['CONNECT', 'DELETE', 'GET', 'HEAD', 'OPTIONS', 'POST', 'PUT', 'PATCH'],
       hosts: []
     },
     introspect: {
@@ -103,7 +103,7 @@ const oAuthServerSchema = {
       append_path: false,
       enable_load_balancing: false,
       methods: [],
-      all_methods: ['ALL', 'CONNECT', 'DELETE', 'GET', 'HEAD', 'OPTIONS', 'POST', 'PUT', 'PATCH'],
+      all_methods: ['CONNECT', 'DELETE', 'GET', 'HEAD', 'OPTIONS', 'POST', 'PUT', 'PATCH'],
       hosts: []
     },
     revoke: {
@@ -138,7 +138,7 @@ const oAuthServerSchema = {
       append_path: false,
       enable_load_balancing: false,
       methods: [],
-      all_methods: ['ALL', 'CONNECT', 'DELETE', 'GET', 'HEAD', 'OPTIONS', 'POST', 'PUT', 'PATCH'],
+      all_methods: ['CONNECT', 'DELETE', 'GET', 'HEAD', 'OPTIONS', 'POST', 'PUT', 'PATCH'],
       hosts: []
     }
   },
@@ -215,7 +215,7 @@ const oAuthServerSchema = {
   cors_meta: {
     domains: ['*'],
     methods: [],
-    all_methods: ['ALL', 'CONNECT', 'DELETE', 'GET', 'HEAD', 'OPTIONS', 'POST', 'PUT', 'PATCH'],
+    all_methods: ['CONNECT', 'DELETE', 'GET', 'HEAD', 'OPTIONS', 'POST', 'PUT', 'PATCH'],
     request_headers: ['Origin', 'Authorization', 'Content-Type'],
     exposed_headers: ['X-Debug-Token', 'X-Debug-Token-Link'],
     enabled: true

--- a/tests/features/oauth/01-create-new_spec.js
+++ b/tests/features/oauth/01-create-new_spec.js
@@ -19,7 +19,7 @@ describe('Create New OAuth Server', () => {
 
       // CORS Methods
       cy.get('#react-select-3--value > .Select-input > input')
-        .type('All{enter}', { force: true })
+        .type('GET{enter}', { force: true })
 
       // CORS Request Headers
       cy.get('#react-select-4--value > .Select-input > input')
@@ -107,7 +107,7 @@ describe('Create New OAuth Server', () => {
 
       // Load Balancing HTTP Methods
       cy.get('#react-select-24--value > .Select-input > input')
-        .type('ALL{enter}', { force: true })
+        .type('POST{enter}', { force: true })
 
       // Save
       cy.get('.j-api-form__sticky .j-button.j-button--primary[type="submit"]')
@@ -149,7 +149,7 @@ describe('Create New OAuth Server', () => {
 
       // CORS Methods
       cy.get('#react-select-3--value')
-        .contains('ALL')
+        .contains('GET')
 
       // CORS Request Headers
       cy.get('#react-select-4--value')
@@ -226,7 +226,7 @@ describe('Create New OAuth Server', () => {
 
       // Load Balancing HTTP Methods
       cy.get('#react-select-9--value')
-        .contains('ALL')
+        .contains('POST')
     })
   })
 
@@ -250,7 +250,7 @@ describe('Create New OAuth Server', () => {
 
       // CORS Methods
       cy.get('#react-select-3--value > .Select-input > input')
-        .type('All{enter}', { force: true })
+        .type('GET{enter}', { force: true })
 
       // CORS Request Headers
       cy.get('#react-select-4--value > .Select-input > input')
@@ -337,7 +337,7 @@ describe('Create New OAuth Server', () => {
 
       // Load Balancing HTTP Methods
       cy.get('#react-select-9--value > .Select-input > input')
-        .type('ALL{enter}', { force: true })
+        .type('POST{enter}', { force: true })
 
       // Token
       // Listen Path
@@ -359,7 +359,7 @@ describe('Create New OAuth Server', () => {
 
       // Load Balancing HTTP Methods
       cy.get('#react-select-12--value > .Select-input > input')
-        .type('ALL{enter}', { force: true })
+        .type('POST{enter}', { force: true })
 
       // Revoke
       // Listen Path
@@ -381,7 +381,7 @@ describe('Create New OAuth Server', () => {
 
       // Load Balancing HTTP Methods
       cy.get('#react-select-15--value > .Select-input > input')
-        .type('ALL{enter}', { force: true })
+        .type('DELETE{enter}', { force: true })
 
       // Save
       cy.get('.j-api-form__sticky .j-button.j-button--primary[type="submit"]')
@@ -423,7 +423,7 @@ describe('Create New OAuth Server', () => {
 
       // CORS Methods
       cy.get('#react-select-3--value')
-        .contains('ALL')
+        .contains('GET')
 
       // CORS Request Headers
       cy.get('#react-select-4--value')
@@ -500,7 +500,7 @@ describe('Create New OAuth Server', () => {
 
       // Load Balancing HTTP Methods
       cy.get('#react-select-9--value')
-        .contains('ALL')
+        .contains('POST')
 
       // Token
       // Listen Path
@@ -517,7 +517,7 @@ describe('Create New OAuth Server', () => {
 
       // Load Balancing HTTP Methods
       cy.get('#react-select-9--value')
-        .contains('ALL')
+        .contains('POST')
 
       // Revoke
       // Listen Path
@@ -533,8 +533,8 @@ describe('Create New OAuth Server', () => {
         .should('have.value', oauthJSON.oauth_endpoints.revoke.upstreams.targets[0].target)
 
       // Load Balancing HTTP Methods
-      cy.get('#react-select-9--value')
-        .contains('ALL')
+      cy.get('#react-select-15--value')
+        .contains('DELETE')
 
     })
   })

--- a/tests/fixtures/oauth-introspection.json
+++ b/tests/fixtures/oauth-introspection.json
@@ -45,9 +45,7 @@
       "strip_path": false,
       "append_path": false,
       "enable_load_balancing": false,
-      "methods": [
-        "ALL"
-      ],
+      "methods": [],
       "hosts": []
     },
     "revoke": {
@@ -107,7 +105,7 @@
       "*"
     ],
     "methods": [
-      "ALL"
+      "GET"
     ],
     "request_headers": [
       "Authorization",

--- a/tests/fixtures/oauth-jwt.json
+++ b/tests/fixtures/oauth-jwt.json
@@ -17,9 +17,7 @@
       "strip_path": false,
       "append_path": false,
       "enable_load_balancing": false,
-      "methods": [
-        "ALL"
-      ],
+      "methods": [],
       "hosts": []
     },
     "token": {
@@ -38,9 +36,7 @@
       "strip_path": false,
       "append_path": false,
       "enable_load_balancing": false,
-      "methods": [
-        "ALL"
-      ],
+      "methods": [],
       "hosts": []
     },
     "introspect": {
@@ -73,9 +69,7 @@
       "strip_path": false,
       "append_path": false,
       "enable_load_balancing": false,
-      "methods": [
-        "ALL"
-      ],
+      "methods": [],
       "hosts": []
     }
   },
@@ -121,7 +115,7 @@
       "*"
     ],
     "methods": [
-      "ALL"
+      "GET"
     ],
     "request_headers": [
       "Origin",

--- a/tests/fixtures/seed_oauth_server.db.json
+++ b/tests/fixtures/seed_oauth_server.db.json
@@ -45,9 +45,7 @@
       "strip_path": false,
       "append_path": false,
       "enable_load_balancing": false,
-      "methods": [
-        "ALL"
-      ],
+      "methods": [],
       "hosts": []
     },
     "revoke": {
@@ -106,7 +104,7 @@
       "*"
     ],
     "methods": [
-      "ALL"
+      "GET"
     ],
     "request_headers": [
       "Origin",

--- a/tests/fixtures/seed_oauth_server.json
+++ b/tests/fixtures/seed_oauth_server.json
@@ -46,7 +46,6 @@
       "append_path": false,
       "enable_load_balancing": false,
       "methods": [
-        "ALL"
       ],
       "hosts": []
     },
@@ -106,7 +105,7 @@
       "*"
     ],
     "methods": [
-      "ALL"
+      "GET"
     ],
     "request_headers": [
       "Origin",


### PR DESCRIPTION
#### Description
The `ALL` method is [a special method that can be used in Janus][1]. This value can be used in the API definition to skip the HTTP method check on that endpoint.
However, this value is not valid for CORS `Access-Control-Allow-Methods` header, as it requires the absolute list of methods.

This PR removes the `ALL` method from the list of choose-able CORS methods in the OAuth schema.

[1]: https://github.com/hellofresh/janus/blob/2680a6eebcff9f175b27fdc346fd9011b3eb11a6/pkg/proxy/register.go#L17