### PR TITLE
Add options_passthrough field to CORS plugin

### DIFF
--- a/src/configurations/apiSchema.config.js
+++ b/src/configurations/apiSchema.config.js
@@ -46,7 +46,8 @@ const schema = {
         domains: ['*'],
         methods: ['CONNECT', 'DELETE', 'GET', 'HEAD', 'OPTIONS', 'POST', 'PUT', 'PATCH'],
         request_headers: ['Origin', 'Authorization', 'Content-Type'],
-        exposed_headers: ['X-Debug-Token', 'X-Debug-Token-Link']
+        exposed_headers: ['X-Debug-Token', 'X-Debug-Token-Link'],
+        options_passthrough: false
       }
     },
     {

--- a/src/configurations/pluginsSchema.config.json
+++ b/src/configurations/pluginsSchema.config.json
@@ -6,7 +6,8 @@
       "domains": ["*"],
       "methods": ["GET", "POST", "PUT", "PATCH", "DELETE"],
       "request_headers": ["Origin", "Authorization", "Content-Type"],
-      "exposed_headers": ["X-Debug-Token", "X-Debug-Token-Link"]
+      "exposed_headers": ["X-Debug-Token", "X-Debug-Token-Link"],
+      "options_passthrough": false
     }
   },
   {

--- a/src/modules/forms/plugins/Cors/CorsPlugin.js
+++ b/src/modules/forms/plugins/Cors/CorsPlugin.js
@@ -11,6 +11,7 @@ import Row from '../../../Layout/Row/Row'
 import Label from '../../../../components/Label/Label'
 import Input from '../../../inputs/Input'
 import Hint from '../../../../components/Hint/Hint'
+import Radio from '../../../../components/Radio/Radio'
 import ControlBar from '../ControlBar/ControlBar'
 import MultiSelect from '../../../selects/MultiSelect/MultiSelect'
 import TagSelect from '../../../selects/TagSelect/TagSelect'
@@ -114,6 +115,39 @@ class CorsPlugin extends PureComponent {
               <Hint>Value for the Access-Control-Expose-Headers header.</Hint>
             </Row>
           </Row>
+          <Row className={b('row')()} fullwidth>
+            <Row col>
+              <Label>Options Passthrough</Label>
+              <Row className={b('radio-wrap')()}>
+                <Row className={b('radio')()}>
+                  <Field
+                    name={`${name}.config.options_passthrough`}
+                    component={Radio}
+                    value
+                    normalize={normalizeBoolean}
+                    type='radio'
+                    id='options-passthrough-true'
+                    disabled={previewPage}
+                  />
+                  <Label htmlFor='options-passthrough-true'>Yes</Label>
+                </Row>
+                <Row className={b('radio')()}>
+                  <Field
+                    name={`${name}.config.options_passthrough`}
+                    component={Radio}
+                    value={false}
+                    normalize={normalizeBoolean}
+                    type='radio'
+                    id='options-passthrough-false'
+                    disabled={previewPage}
+                  />
+                  <Label htmlFor='options-passthrough-false'>No</Label>
+                </Row>
+              </Row>
+              <Hint>Instructs preflight to let other potential next handlers to process the OPTIONS method</Hint>
+            </Row>
+            <React.Fragment />
+          </Row>
         </div>
       )
     };
@@ -122,3 +156,9 @@ class CorsPlugin extends PureComponent {
 CorsPlugin.propTypes = propTypes
 
 export default CorsPlugin
+
+function normalizeBoolean (value) {
+  if (value === 'true') return true
+  if (value === 'false') return false
+  return value
+}

--- a/src/modules/forms/plugins/setup.config.js
+++ b/src/modules/forms/plugins/setup.config.js
@@ -4,7 +4,8 @@ export default {
       domains: 'Choose',
       methods: 'Choose one or more methods',
       request_headers: 'eg. Origin, Authorization, Content-Type',
-      exposed_headers: 'eg. X-Debug-Token, X-Debug-Token-Link'
+      exposed_headers: 'eg. X-Debug-Token, X-Debug-Token-Link',
+      options_passthrough: false
     },
     auth: {
       server_name: 'Choose'

--- a/tests/features/api/02-import-json_spec.js
+++ b/tests/features/api/02-import-json_spec.js
@@ -23,6 +23,9 @@ describe('Import JSON', () => {
       cy.get('.uploader')
         .trigger('drop', dropEvent).then(() => {
 
+        // Wait until editor appears, indicating successful upload
+        cy.get('#gw-json-editor')
+
         // Confirm upload
         cy.get('.j-confirmation-container > .j-confirmation__buttons-group > .j-button--primary')
           .click({ force: true })


### PR DESCRIPTION
Adds a new field on CORS plugin for `options_passthrough` option.

#### Related
https://github.com/hellofresh/janus/pull/351
https://github.com/rs/cors#parameters