### PR TITLE
Fix Empty List Page Content

### DIFF
--- a/src/modules/pages/ApiListPage/ApiList.js
+++ b/src/modules/pages/ApiListPage/ApiList.js
@@ -167,9 +167,9 @@ class ApiList extends PureComponent {
 
       if (this.props.apiList.isFetching) {
         return <Preloader />
-      } else {
-        return <NoSearchResults />
       }
+
+      return <NoSearchResults />
     }
 }
 

--- a/src/modules/pages/ApiListPage/ApiList.js
+++ b/src/modules/pages/ApiListPage/ApiList.js
@@ -5,7 +5,6 @@ import {
 } from 'react-router-dom'
 
 import block from '../../../helpers/bem-cn'
-import isNoSearchResults from '../../../helpers/isNoSearchResults'
 
 import PaginatedList from '../../PaginatedList/PaginatedList'
 import Button from '../../../components/Button/Button'
@@ -166,11 +165,11 @@ class ApiList extends PureComponent {
         )
       }
 
-      if (isNoSearchResults(this.props.searchQuery)) {
+      if (this.props.apiList.isFetching) {
+        return <Preloader />
+      } else {
         return <NoSearchResults />
       }
-
-      return <Preloader />
     }
 }
 

--- a/src/modules/pages/OAuthServersPage/OAuthServersList.js
+++ b/src/modules/pages/OAuthServersPage/OAuthServersList.js
@@ -6,7 +6,6 @@ import {
 } from 'react-router-dom'
 
 import block from '../../../helpers/bem-cn'
-import isNoSearchResults from '../../../helpers/isNoSearchResults'
 import ROUTES from '../../../configurations/routes.config'
 
 import PaginatedList from '../../PaginatedList/PaginatedList'
@@ -102,11 +101,11 @@ class OAuthServersList extends PureComponent {
       )
     }
 
-    if (isNoSearchResults(this.props.searchQuery)) {
+    if (this.props.oAuthServers.isFetching) {
+      return <Preloader />
+    } else {
       return <NoSearchResults />
     }
-
-    return <Preloader />
   }
 }
 


### PR DESCRIPTION
Fixes API Definitions and OAuth Servers list pages showing preloader if Janus returns valid, but empty list.