### PR TITLE
Update regexp pattern for API Name validation

### DIFF
--- a/src/configurations/warning-messages.config.js
+++ b/src/configurations/warning-messages.config.js
@@ -1,5 +1,5 @@
 export default {
   LISTEN_PATH: 'Listen path should start from "/".',
-  NAMES: 'The name should contain only letters, "-" and/or "_".',
+  NAMES: 'The name should contain only alphanumeric letters and "-"',
   URL: 'Should be a valid url format("http://..." or "https://...").'
 }

--- a/src/helpers/validation.js
+++ b/src/helpers/validation.js
@@ -14,7 +14,7 @@ import R from 'ramda'
 const validation = pattern => value => {
   switch (pattern) {
     case 'name': {
-      const nameRegex = /^[a-z_-]{1,100}$/
+      const nameRegex = /^[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*$/
 
       return nameRegex.test(value)
     }

--- a/src/modules/pages/NewOAuthServerPage/OAuthServerForm.js
+++ b/src/modules/pages/NewOAuthServerPage/OAuthServerForm.js
@@ -10,7 +10,6 @@ import PLACEHOLDER from '../../../configurations/placeholders.config'
 import WARNINGS from '../../../configurations/warning-messages.config'
 
 import block from '../../../helpers/bem-cn'
-import checkOnPattern from '../../../helpers/pattern-check'
 import optionsTransformer from '../../../helpers/optionsTransformer'
 import getValues from '../../../helpers/getValues'
 import parse from '../../../helpers/parse-value'
@@ -295,7 +294,6 @@ class OAuthServerForm extends PureComponent {
                     type='text'
                     component={Input}
                     disabled={editing}
-                    validate={checkOnPattern('name')}
                     required
                   />
                   <span className='j-input__warning'>{WARNINGS.NAMES}</span>


### PR DESCRIPTION
Update API name validation pattern to match the validation pattern used on Janus:
https://github.com/hellofresh/janus/blob/28dabbdaf63673eb62bf80df1c09d110cb6b638d/pkg/api/api.go#L20