### PR TITLE
Rate Limit Plugin: Fix wrong key name

### DIFF
--- a/src/modules/forms/plugins/RateLimit/RateLimitPlugin.js
+++ b/src/modules/forms/plugins/RateLimit/RateLimitPlugin.js
@@ -152,7 +152,7 @@ class RateLimitPlugin extends PureComponent {
               <Row className={b('radio-wrap')()}>
                 <Row className={b('radio')()}>
                   <Field
-                    name={`${name}.config.trust_forwarded_headers`}
+                    name={`${name}.config.trust_forward_headers`}
                     component={Radio}
                     value
                     normalize={normalizeBoolean}
@@ -164,7 +164,7 @@ class RateLimitPlugin extends PureComponent {
                 </Row>
                 <Row className={b('radio')()}>
                   <Field
-                    name={`${name}.config.trust_forwarded_headers`}
+                    name={`${name}.config.trust_forward_headers`}
                     component={Radio}
                     value={false}
                     normalize={normalizeBoolean}


### PR DESCRIPTION
This PR fixes invalid key name used in hellofresh/janus#400.